### PR TITLE
Fix logic in `getKeys` function to handle trailing commas in key unbinding

### DIFF
--- a/keymaster.js
+++ b/keymaster.js
@@ -243,6 +243,7 @@
     keys = key.split(',');
     if ((keys[keys.length - 1]) == '') {
       keys[keys.length - 2] += ',';
+      keys.pop();
     }
     return keys;
   }
@@ -266,7 +267,6 @@
   // set the handlers globally on document
   addEvent(document, 'keydown', function(event) { dispatch(event) }); // Passing _scope to a callback to ensure it remains the same by execution. Fixes #48
   addEvent(document, 'keyup', clearModifier);
-
   // reset modifiers to false whenever the window is (re)focused.
   addEvent(window, 'focus', resetModifiers);
 


### PR DESCRIPTION
Fix logic in getKeys function to handle trailing commas in key unbinding